### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/hcloud.py
+++ b/hcloud.py
@@ -18,7 +18,7 @@ def main():
         hosts.append(server_name)
         hostvars[server_name] = fill_host_vars(server)
         add_to_datacenter(root, server)
-    print json.dumps(root)
+    print(json.dumps(root))
 
 def fill_host_vars(server):
     return {


### PR DESCRIPTION
This change adds Python 3 compatibility by fixing the following syntax error:

```
  File "./hcloud.py", line 21
    print json.dumps(root)
             ^
SyntaxError: invalid syntax
```