### PR TITLE
Workaround empty image in JSON response

### DIFF
--- a/hcloud.py
+++ b/hcloud.py
@@ -27,7 +27,7 @@ def fill_host_vars(server):
     return {
         'ansible_host': server['public_net']['ipv4']['ip'],
         'hcloud_server_type': server['server_type'],
-        'hcloud_image': server['image']['name'],
+        'hcloud_image': getattr(server['image'], 'name', ''),
         'hcloud_datacenter': server['datacenter']['name'],
         'hcloud_labels': server['labels'],
     }


### PR DESCRIPTION
Fix for recent error:
```
Traceback (most recent call last):
  File "hcloud.py", line 50, in <module>
    main()
  File "hcloud.py", line 22, in main
    hostvars[server_name] = fill_host_vars(server)
  File "hcloud.py", line 31, in fill_host_vars
    'hcloud_image': server['image']['name'],
```