### PR TITLE
Add IPv6 support

### DIFF
--- a/hcloud.ini
+++ b/hcloud.ini
@@ -1,0 +1,4 @@
+[hcloud]
+# Uncomment this if you want to reach servers via IPv6.
+# Valid options: ipv4, ipv6. Default: ipv4.
+#public_net = ipv6

--- a/hcloud.py
+++ b/hcloud.py
@@ -6,8 +6,12 @@ import json
 import requests
 import os
 import sys
-import ConfigParser
 import ipaddress
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 
 def main():
@@ -60,14 +64,14 @@ def fill_host_vars(server, public_net):
 
 def add_to_datacenter(root, server):
     dc = server['datacenter']['name']
-    if not root.has_key(dc):
+    if dc not in root:
         root[dc] = { 'hosts': [] }
     root[dc]['hosts'].append(server['name'])
 
 def add_to_labels(root, server):
     for label in server['labels']:
       vlabel=label + '-' + server['labels'][label]
-      if not root.has_key(vlabel):
+      if vlabel not in root:
           root[vlabel] = { 'hosts': [] }
       root[vlabel]['hosts'].append(server['name'])
 

--- a/hcloud.py
+++ b/hcloud.py
@@ -6,8 +6,18 @@ import json
 import requests
 import os
 import sys
+import ConfigParser
+import ipaddress
+
 
 def main():
+    config = ConfigParser.ConfigParser()
+    config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'hcloud.ini')
+    config.read(config_path)
+    if config.has_option('hcloud', 'public_net'):
+        public_net = config.get('hcloud', 'public_net')
+    else:
+        public_net = 'ipv4'
     api_key = os.environ.get('HCLOUD_TOKEN')
     if not api_key:
         try:
@@ -28,14 +38,20 @@ def main():
     for server in r.json()['servers']:
         server_name = server['name']
         hosts.append(server_name)
-        hostvars[server_name] = fill_host_vars(server)
+        hostvars[server_name] = fill_host_vars(server, public_net)
         add_to_datacenter(root, server)
         add_to_labels(root, server)
     print(json.dumps(root))
 
-def fill_host_vars(server):
+def fill_host_vars(server, public_net):
+    ip = server['public_net'][public_net]['ip']
+    # In case op IPv6, set the IP to the first address of the assigned range.
+    if public_net == "ipv6":
+        ansible_host = str(ipaddress.ip_network(ip)[1])
+    else:
+        ansible_host = ip
     return {
-        'ansible_host': server['public_net']['ipv4']['ip'],
+        'ansible_host': ansible_host,
         'hcloud_server_type': server['server_type'],
         'hcloud_image': getattr(server['image'], 'name', ''),
         'hcloud_datacenter': server['datacenter']['name'],


### PR DESCRIPTION
This adds support to query the IPv6 addresses of servers. Default
is still to query IPv4 addresses if config file is missing or
config option is unset.