### PR TITLE
Support more than 25 servers by considering pagination

### DIFF
--- a/hcloud.ini
+++ b/hcloud.ini
@@ -2,3 +2,4 @@
 # Uncomment this if you want to reach servers via IPv6.
 # Valid options: ipv4, ipv6. Default: ipv4.
 #public_net = ipv6
+#per_page = 25


### PR DESCRIPTION
By default the Hetzner API only returns 25 items in responses which contain arrays.
To get all servers it is required to send multiple requests with different page numbers.
https://docs.hetzner.cloud/#overview-pagination
This PR detects if the next_page parameter is set and fetches the next page until it requested the last page. Additionally it is possible to configure the per_page parameter as a config option.