### PR TITLE
Add support for private ip address as ansible host

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The host have the following hostvars
 
 Name | Description
 ---- | ----
-ansible_host | Public IPv4 Adress
+ansible_host | Public or private IPv4 or IPv6 Address
+ansible_public_net | Public IPv4 Address
+ansible_private_net | Private IPv4 Address
 hcloud_server_type | Servertype eg. CX11
 hcloud_image | Name of the used image
 hcloud_datacenter | Datacenter the server is running in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ansible-hcloud-inventory
-An dynamic inventory script for hetzner cloud
+A dynamic inventory script for hetzner cloud.
 
 Usage:
 `HCLOUD_TOKEN=example ansible-playbook site.yml -u root -i hcloud.py`
@@ -24,7 +24,7 @@ nbg1_dc3 | contains all hosts in datacenter Nürnberg
 label1_value1 | contains all hosts have label "label1"="value1"
 label1_value2 | contains all hosts have label "label1"="value2"
 
-The host have the following hostvars 
+The host has the following hostvars:
 
 Name | Description
 ---- | ----
@@ -35,3 +35,5 @@ hcloud_server_type | Servertype eg. CX11
 hcloud_image | Name of the used image
 hcloud_datacenter | Datacenter the server is running in
 hcloud_labels | Instance labels
+
+Check the [hcloud.ini](hcloud.ini) for a short explanation on how to use the ipv6 address of a server as or the private ip address of a server as value for `ansible_host`.

--- a/hcloud.ini
+++ b/hcloud.ini
@@ -3,3 +3,8 @@
 # Valid options: ipv4, ipv6. Default: ipv4.
 #public_net = ipv6
 #per_page = 25
+# Uncomment this if you want to get the private ip address instead of the public one.
+# This is useful in case you're having hosts inside a private net which you're not able to reach by their public address.
+#use_private_ip=yes
+# If you've got multiple private nets and want to ip address of a specific net, set the index number of the net here
+#private_net_index=0

--- a/hcloud.py
+++ b/hcloud.py
@@ -19,17 +19,17 @@ def main():
     config = ConfigParser.ConfigParser()
     config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'hcloud.ini')
     config.read(config_path)
-    if config.has_option('hcloud', 'public_net'):
-        public_net_type = config.get('hcloud', 'public_net')
-    else:
-        public_net_type = 'ipv4'
-    if config.has_option('hcloud', 'per_page'):
-        per_page = config.get('hcloud', 'per_page')
-    else:
-        per_page = 25
+
+    # parse config
+    public_net_type = config.get('hcloud', 'public_net', fallback="ipv4")
+    use_private_ip = config.getboolean('hcloud', 'use_private_ip', fallback=False)
+    private_net_index = config.getint('hcloud', 'private_net_index', fallback=0)
+    per_page = config.getint('hcloud', 'per_page', fallback=25)
     if per_page > 50:
         print("The per_page config option must not be greater than 50.")
         exit(1)
+
+    # get api token
     if len(sys.argv) > 1 and sys.argv[1].find('@') > -1:
         with open(sys.argv[1].replace('@', ''), 'r') as stream:
             try:
@@ -48,10 +48,12 @@ def main():
                 "variable or set like first argument for script"
             )
             exit(1)
+
+    # get servers
     hosts = []
     hostvars = {}
     page = 1
-    root = { 'hcloud': {'hosts': hosts}, '_meta': { 'hostvars': hostvars }}
+    root = {'hcloud': {'hosts': hosts}, '_meta': {'hostvars': hostvars}}
     url = 'https://api.hetzner.cloud/v1/'
     headers = {'Authorization': 'Bearer ' + api_key}
     while True:
@@ -59,27 +61,34 @@ def main():
         for server in r.json()['servers']:
             server_name = server['name']
             hosts.append(server_name)
-            hostvars[server_name] = fill_host_vars(server, public_net_type, url, headers)
+            hostvars[server_name] = fill_host_vars(server, public_net_type, use_private_ip, private_net_index, url,
+                                                   headers)
             add_to_datacenter(root, server)
             add_to_labels(root, server)
         if r.json()['meta']['pagination']['next_page'] is None:
-            break;
+            break
         else:
             page += 1
     print(json.dumps(root))
 
-def fill_host_vars(server, public_net_type, url, headers):
-    ip = server['public_net'][public_net_type]['ip']
-    # In case op IPv6, set the IP to the first address of the assigned range.
+
+def fill_host_vars(server, public_net_type, use_private_ip, private_net_index, url, headers):
+    if use_private_ip:
+        ip = server['private_net'][private_net_index]['ip']
+    else:
+        ip = server['public_net'][public_net_type]['ip']
+    # In case of IPv6, set the IP to the first address of the assigned range.
     if public_net_type == "ipv6":
         ansible_host = str(ipaddress.ip_network(ip)[1])
     else:
         ansible_host = ip
+
     public_net = server['public_net']
+    private_net = server['private_net']
     floating_ips_ids = public_net['floating_ips']
     public_net['floating_ips'] = {'ipv4': [], 'ipv6': []}
-    for id in floating_ips_ids:
-        r = requests.get(url + "floating_ips/{}".format(id), headers=headers)
+    for ip_id in floating_ips_ids:
+        r = requests.get(url + "floating_ips/{}".format(ip_id), headers=headers)
         floating_ip = r.json()['floating_ip']
         ip_type = floating_ip['type']
         ip = floating_ip['ip']
@@ -88,24 +97,28 @@ def fill_host_vars(server, public_net_type, url, headers):
     return {
         'ansible_host': ansible_host,
         'hcloud_public_net': public_net,
+        'hcloud_private_net': private_net,
         'hcloud_server_type': server['server_type'],
         'hcloud_image': getattr(server['image'], 'name', ''),
         'hcloud_datacenter': server['datacenter']['name'],
         'hcloud_labels': server['labels'],
     }
 
+
 def add_to_datacenter(root, server):
     dc = server['datacenter']['name'].replace("-", "_")
     if dc not in root:
-        root[dc] = { 'hosts': [] }
+        root[dc] = {'hosts': []}
     root[dc]['hosts'].append(server['name'])
+
 
 def add_to_labels(root, server):
     for label in server['labels']:
-      vlabel=label + '_' + server['labels'][label]
+      vlabel = label + '_' + server['labels'][label]
       if vlabel not in root:
           root[vlabel] = { 'hosts': [] }
       root[vlabel]['hosts'].append(server['name'])
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This PR makes it possible to use the private ip address of a host as ansible_host address instead of the public address.

This is useful in a scenario where you use the new networks feature to "hide" most of your servers behind a firewall so that they're not available from the outside anymore. In my case I'm still able to connect to the remote hosts using VPN but If I want to make the hosts avaible to AnsibleI have to specify the private ip address instead of the public one.

My modification makes this inventory script return the private ip address of a host as value of the "ansible_host" variable. This behaviour is disabled by default. One has to uncomment the `use_private_ip` setting inside the config file to enable this behaviour.