### PR TITLE
give group alias to label_value 

### DIFF
--- a/hcloud.ini
+++ b/hcloud.ini
@@ -8,3 +8,7 @@
 #use_private_ip=yes
 # If you've got multiple private nets and want to ip address of a specific net, set the index number of the net here
 #private_net_index=0
+
+[hcloud.groupaliases]
+dnsservers = dns_true
+webservers = web_true

--- a/hcloud.ini
+++ b/hcloud.ini
@@ -9,6 +9,7 @@
 # If you've got multiple private nets and want to ip address of a specific net, set the index number of the net here
 #private_net_index=0
 
-[hcloud.groupaliases]
-dnsservers = dns_true
-webservers = web_true
+# Uncomment and edit these if you want to use labels on hetzner cloud server as groups
+# [hcloud.groupaliases]
+# dnsservers = dns_true
+# webservers = web_true

--- a/hcloud.py
+++ b/hcloud.py
@@ -69,6 +69,12 @@ def main():
             break
         else:
             page += 1
+    
+    if config.has_section('hcloud.groupaliases'):
+        for groupalias, label_value in config.items('hcloud.groupaliases'):
+            if label_value in root:
+                root[groupalias] = root[label_value]
+
     print(json.dumps(root))
 
 


### PR DESCRIPTION
so that ansible inventory usage can be streamlined.

It is easy to give "web=true" label in hcloud.
Group "webservers" can be used in ansible easily with this change.